### PR TITLE
rearrange action_creators

### DIFF
--- a/manuscript/05-redux-advanced/03-redux-architecture.md
+++ b/manuscript/05-redux-advanced/03-redux-architecture.md
@@ -1363,14 +1363,14 @@ import {
   STORIES_FETCH,
 } from '../constants/actionTypes';
 
-const doAddStories = stories => ({
-  type: STORIES_ADD,
-  stories,
-});
-
 const doFetchStories = query => ({
   type: STORIES_FETCH,
   query,
+});
+
+const doAddStories = stories => ({
+  type: STORIES_ADD,
+  stories,
 });
 
 export {


### PR DESCRIPTION
Hello, I've just swapped these two action creators, based on:

- Before: "the first one that activates the side-effect to fetch stories by a search term and the second one that adds the fetched stories to your Redux store."

- After: "only the second action needs to be intercepted in your storyReducer to store the stories. The first action is only used to activate the saga in your root saga."

Hope that I can help! Thank you for reading this.